### PR TITLE
build(github): group dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      dev-dependencies:
+        - "*"


### PR DESCRIPTION
They can go in together. No need to run the pipeline separately for each
change since we want to do one release if possible.
