### PR TITLE
fix(release): use npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,5 +34,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm exec semantic-release


### PR DESCRIPTION
## Summary
Switches the release workflow to npm OIDC trusted publishing and drops the long-lived `NPM_TOKEN` secret.

semantic-release v25 / @semantic-release/npm v13 try OIDC first and fall back to `NPM_TOKEN`. The current main is failing both paths — OIDC because the workflow lacks `id-token: write`, NPM_TOKEN because the secret is invalid (401 from `/-/whoami`). See #128 for the recurring failures.

## Required follow-up (npmjs.com side — outside this PR)
After merging, configure the trusted publisher on npmjs.com:

1. Go to https://www.npmjs.com/package/get-notion-object-title/access (or Account → Packages → this package → Settings)
2. Trusted Publishers → **Add GitHub Actions publisher**
   - Organization or user: `2anki`
   - Repository: `get-notion-object-title`
   - Workflow filename: `create-release.yml`
   - Environment: *(leave blank — the workflow doesn't use one)*
3. The stale `NPM_TOKEN` GitHub secret can be deleted afterward (no longer referenced).

Closes #128.

## Test plan
- [x] `pnpm format:check` passes
- [ ] First push to `main` after merge + npm trusted-publisher config triggers a successful release

🤖 Generated with [Claude Code](https://claude.com/claude-code)